### PR TITLE
fix(network): select primary adapter for AirPlay

### DIFF
--- a/AirPlayServerLib/lib/dnssd.c
+++ b/AirPlayServerLib/lib/dnssd.c
@@ -36,21 +36,8 @@
 #include "compat.h"
 #include "utils.h"
 
-#ifdef WIN32
-#include <iphlpapi.h>
-#pragma comment(lib, "iphlpapi.lib")
-#endif
-
 #define MAX_DEVICEID 18
 #define MAX_SERVNAME 256
-#define MAX_INTERFACES 16
-
-/* Structure to hold network interface information */
-typedef struct {
-	char hwaddr[MAX_HWADDR_LEN];
-	uint32_t ifIndex;
-	int valid;
-} network_interface_t;
 
 #if defined(HAVE_LIBDL) && !defined(__APPLE__)
 # define USE_LIBDL 1
@@ -142,15 +129,8 @@ struct dnssd_s {
 	TXTRecordGetBytesPtr_t     TXTRecordGetBytesPtr;
 	TXTRecordDeallocate_t      TXTRecordDeallocate;
 
-	/* Support multiple services for multi-interface advertisement */
-	DNSServiceRef raopServices[MAX_INTERFACES];
-	DNSServiceRef airplayServices[MAX_INTERFACES];
-	int raopServiceCount;
-	int airplayServiceCount;
-
-	/* Store network interfaces for registration */
-	network_interface_t interfaces[MAX_INTERFACES];
-	int interfaceCount;
+	DNSServiceRef raopService;
+	DNSServiceRef airplayService;
 };
 
 
@@ -240,76 +220,6 @@ dnssd_destroy(dnssd_t *dnssd)
 	}
 }
 
-/* Enumerate all active network interfaces with MAC addresses */
-static int
-enumerate_network_interfaces(dnssd_t *dnssd)
-{
-	int count = 0;
-
-#ifdef WIN32
-	PIP_ADAPTER_ADDRESSES pAddresses = NULL;
-	PIP_ADAPTER_ADDRESSES pCurrAddresses = NULL;
-	ULONG outBufLen = 0;
-	ULONG flags = GAA_FLAG_INCLUDE_PREFIX;
-	DWORD dwRetVal = 0;
-
-	/* First call to determine required buffer size */
-	outBufLen = sizeof(IP_ADAPTER_ADDRESSES);
-	pAddresses = (IP_ADAPTER_ADDRESSES *)malloc(outBufLen);
-	if (pAddresses == NULL) {
-		return 0;
-	}
-
-	dwRetVal = GetAdaptersAddresses(AF_UNSPEC, flags, NULL, pAddresses, &outBufLen);
-	if (dwRetVal == ERROR_BUFFER_OVERFLOW) {
-		free(pAddresses);
-		pAddresses = (IP_ADAPTER_ADDRESSES *)malloc(outBufLen);
-		if (pAddresses == NULL) {
-			return 0;
-		}
-	}
-
-	dwRetVal = GetAdaptersAddresses(AF_UNSPEC, flags, NULL, pAddresses, &outBufLen);
-	if (dwRetVal != NO_ERROR) {
-		free(pAddresses);
-		return 0;
-	}
-
-	/* Iterate through all adapters */
-	pCurrAddresses = pAddresses;
-	while (pCurrAddresses && count < MAX_INTERFACES) {
-		/* Only include adapters that are up and have a valid MAC address */
-		if (pCurrAddresses->OperStatus == IfOperStatusUp &&
-			pCurrAddresses->PhysicalAddressLength == MAX_HWADDR_LEN &&
-			pCurrAddresses->IfType != IF_TYPE_SOFTWARE_LOOPBACK &&
-			pCurrAddresses->IfType != IF_TYPE_TUNNEL) {
-
-			/* Copy MAC address */
-			for (int i = 0; i < MAX_HWADDR_LEN; i++) {
-				dnssd->interfaces[count].hwaddr[i] = pCurrAddresses->PhysicalAddress[i];
-			}
-			/* Use the interface index (IfIndex for IPv4, Ipv6IfIndex for IPv6) */
-			dnssd->interfaces[count].ifIndex = pCurrAddresses->IfIndex;
-			dnssd->interfaces[count].valid = 1;
-			count++;
-		}
-		pCurrAddresses = pCurrAddresses->Next;
-	}
-
-	free(pAddresses);
-#else
-	/* For non-Windows platforms, use interface index 0 (any) with a placeholder MAC */
-	/* A more complete implementation would use getifaddrs() on Linux/macOS */
-	dnssd->interfaces[0].ifIndex = 0;
-	dnssd->interfaces[0].valid = 1;
-	memset(dnssd->interfaces[0].hwaddr, 0, MAX_HWADDR_LEN);
-	count = 1;
-#endif
-
-	dnssd->interfaceCount = count;
-	return count;
-}
-
 static void __stdcall MyRegisterServiceReply
 (
 	DNSServiceRef                       sdRef,
@@ -330,106 +240,64 @@ dnssd_register_raop(dnssd_t *dnssd, const char *name, unsigned short port, const
 	char servname[MAX_SERVNAME];
 	char features[32];
 	int ret;
-	int i;
-	int registered = 0;
-	const char *if_hwaddr;
 
 	assert(dnssd);
 	assert(name);
 	assert(hwaddr);
 
-	/* Enumerate network interfaces if not already done */
-	if (dnssd->interfaceCount == 0) {
-		enumerate_network_interfaces(dnssd);
+	ret = utils_hwaddr_raop(servname, sizeof(servname), hwaddr, hwaddrlen);
+	if (ret < 0) {
+		return -1;
 	}
-
-	/* If no interfaces found, fall back to provided hwaddr on all interfaces */
-	if (dnssd->interfaceCount == 0) {
-		dnssd->interfaces[0].ifIndex = 0;  /* kDNSServiceInterfaceIndexAny */
-		memcpy(dnssd->interfaces[0].hwaddr, hwaddr, hwaddrlen);
-		dnssd->interfaces[0].valid = 1;
-		dnssd->interfaceCount = 1;
+	if (sizeof(servname) < strlen(servname) + 1 + strlen(name) + 1) {
+		return -1;
 	}
+	strncat(servname, "@", sizeof(servname) - strlen(servname) - 1);
+	strncat(servname, name, sizeof(servname) - strlen(servname) - 1);
 
 	snprintf(features, sizeof(features), "0x%X,0x%X", GLOBAL_FEATURES_1, GLOBAL_FEATURES_2);
 
-	dnssd->raopServiceCount = 0;
+	dnssd->TXTRecordCreate(&txtRecord, 0, NULL);
+	dnssd->TXTRecordSetValue(&txtRecord, "txtvers", strlen(RAOP_TXTVERS), RAOP_TXTVERS);
+	dnssd->TXTRecordSetValue(&txtRecord, "ch", strlen(RAOP_CH), RAOP_CH);
+	dnssd->TXTRecordSetValue(&txtRecord, "cn", strlen(RAOP_CN), RAOP_CN);
+	dnssd->TXTRecordSetValue(&txtRecord, "et", strlen(RAOP_ET), RAOP_ET);
+	dnssd->TXTRecordSetValue(&txtRecord, "sv", strlen(RAOP_SV), RAOP_SV);
+	dnssd->TXTRecordSetValue(&txtRecord, "da", strlen(RAOP_DA), RAOP_DA);
+	dnssd->TXTRecordSetValue(&txtRecord, "sr", strlen(RAOP_SR), RAOP_SR);
+	dnssd->TXTRecordSetValue(&txtRecord, "ss", strlen(RAOP_SS), RAOP_SS);
+	dnssd->TXTRecordSetValue(&txtRecord, "pw",
+		password ? strlen("true") : strlen("false"),
+		password ? "true" : "false");
+	dnssd->TXTRecordSetValue(&txtRecord, "vn", strlen(RAOP_VN), RAOP_VN);
+	dnssd->TXTRecordSetValue(&txtRecord, "tp", strlen(RAOP_TP), RAOP_TP);
+	dnssd->TXTRecordSetValue(&txtRecord, "md", strlen(RAOP_MD), RAOP_MD);
+	dnssd->TXTRecordSetValue(&txtRecord, "vs", strlen(GLOBAL_VERSION), GLOBAL_VERSION);
+	dnssd->TXTRecordSetValue(&txtRecord, "sm", strlen(RAOP_SM), RAOP_SM);
+	dnssd->TXTRecordSetValue(&txtRecord, "ek", strlen(RAOP_EK), RAOP_EK);
+	dnssd->TXTRecordSetValue(&txtRecord, "sf",
+		password ? strlen("0x84") : strlen(RAOP_SF),
+		password ? "0x84" : RAOP_SF);
+	dnssd->TXTRecordSetValue(&txtRecord, "ft", strlen(features), features);
+	dnssd->TXTRecordSetValue(&txtRecord, "am", strlen(GLOBAL_MODEL), GLOBAL_MODEL);
 
-	/* Register service on each interface */
-	for (i = 0; i < dnssd->interfaceCount && i < MAX_INTERFACES; i++) {
-		if (!dnssd->interfaces[i].valid) {
-			continue;
-		}
+	dnssd->raopService = NULL;
+	ret = dnssd->DNSServiceRegister(&dnssd->raopService,
+		0, 0, /* kDNSServiceInterfaceIndexAny */
+		servname, "_raop._tcp",
+		NULL, NULL,
+		htons(port),
+		dnssd->TXTRecordGetLength(&txtRecord),
+		dnssd->TXTRecordGetBytesPtr(&txtRecord),
+		MyRegisterServiceReply, NULL);
+	dnssd->TXTRecordDeallocate(&txtRecord);
 
-		/* Use the interface's MAC address or fallback to provided hwaddr */
-		if_hwaddr = dnssd->interfaces[i].hwaddr;
-		if (if_hwaddr[0] == 0 && if_hwaddr[1] == 0 && if_hwaddr[2] == 0 &&
-			if_hwaddr[3] == 0 && if_hwaddr[4] == 0 && if_hwaddr[5] == 0) {
-			if_hwaddr = hwaddr;
-		}
-
-		dnssd->TXTRecordCreate(&txtRecord, 0, NULL);
-		dnssd->TXTRecordSetValue(&txtRecord, "txtvers", strlen(RAOP_TXTVERS), RAOP_TXTVERS);
-		dnssd->TXTRecordSetValue(&txtRecord, "ch", strlen(RAOP_CH), RAOP_CH);
-		dnssd->TXTRecordSetValue(&txtRecord, "cn", strlen(RAOP_CN), RAOP_CN);
-		dnssd->TXTRecordSetValue(&txtRecord, "et", strlen(RAOP_ET), RAOP_ET);
-		dnssd->TXTRecordSetValue(&txtRecord, "sv", strlen(RAOP_SV), RAOP_SV);
-		dnssd->TXTRecordSetValue(&txtRecord, "da", strlen(RAOP_DA), RAOP_DA);
-		dnssd->TXTRecordSetValue(&txtRecord, "sr", strlen(RAOP_SR), RAOP_SR);
-		dnssd->TXTRecordSetValue(&txtRecord, "ss", strlen(RAOP_SS), RAOP_SS);
-		if (password) {
-			dnssd->TXTRecordSetValue(&txtRecord, "pw", strlen("true"), "true");
-		} else {
-			dnssd->TXTRecordSetValue(&txtRecord, "pw", strlen("false"), "false");
-		}
-		dnssd->TXTRecordSetValue(&txtRecord, "vn", strlen(RAOP_VN), RAOP_VN);
-		dnssd->TXTRecordSetValue(&txtRecord, "tp", strlen(RAOP_TP), RAOP_TP);
-		dnssd->TXTRecordSetValue(&txtRecord, "md", strlen(RAOP_MD), RAOP_MD);
-		dnssd->TXTRecordSetValue(&txtRecord, "vs", strlen(GLOBAL_VERSION), GLOBAL_VERSION);
-		dnssd->TXTRecordSetValue(&txtRecord, "sm", strlen(RAOP_SM), RAOP_SM);
-		dnssd->TXTRecordSetValue(&txtRecord, "ek", strlen(RAOP_EK), RAOP_EK);
-		dnssd->TXTRecordSetValue(&txtRecord, "sf",
-			password ? strlen("0x84") : strlen(RAOP_SF),
-			password ? "0x84" : RAOP_SF);
-		dnssd->TXTRecordSetValue(&txtRecord, "ft", strlen(features), features);
-		dnssd->TXTRecordSetValue(&txtRecord, "am", strlen(GLOBAL_MODEL), GLOBAL_MODEL);
-
-		/* Convert hardware address to string */
-		ret = utils_hwaddr_raop(servname, sizeof(servname), if_hwaddr, hwaddrlen);
-		if (ret < 0) {
-			dnssd->TXTRecordDeallocate(&txtRecord);
-			continue;
-		}
-
-		/* Check that we have bytes for 'hw@name' format */
-		if (sizeof(servname) < strlen(servname)+1+strlen(name)+1) {
-			dnssd->TXTRecordDeallocate(&txtRecord);
-			continue;
-		}
-
-		strncat(servname, "@", sizeof(servname)-strlen(servname)-1);
-		strncat(servname, name, sizeof(servname)-strlen(servname)-1);
-
-		/* Register the service on this interface */
-		ret = dnssd->DNSServiceRegister(&dnssd->raopServices[dnssd->raopServiceCount],
-		                          0, dnssd->interfaces[i].ifIndex,
-		                          servname, "_raop._tcp",
-		                          NULL, NULL,
-		                          htons(port),
-		                          dnssd->TXTRecordGetLength(&txtRecord),
-		                          dnssd->TXTRecordGetBytesPtr(&txtRecord),
-			MyRegisterServiceReply, NULL);
-
-		/* Deallocate TXT record */
-		dnssd->TXTRecordDeallocate(&txtRecord);
-
-		if (ret == 0) {
-			dnssd->raopServiceCount++;
-			registered++;
-		}
+	if (ret != 0) {
+		dnssd->raopService = NULL;
+		return -1;
 	}
 
-	return registered > 0 ? 1 : -1;
+	return 1;
 }
 
 int
@@ -440,111 +308,66 @@ dnssd_register_airplay(dnssd_t *dnssd, const char *name, unsigned short port,
 	char deviceid[3*MAX_HWADDR_LEN];
 	char features[32];
 	int ret;
-	int i;
-	int registered = 0;
-	const char *if_hwaddr;
 
 	assert(dnssd);
 	assert(name);
 	assert(hwaddr);
 
-	/* Enumerate network interfaces if not already done */
-	if (dnssd->interfaceCount == 0) {
-		enumerate_network_interfaces(dnssd);
-	}
-
-	/* If no interfaces found, fall back to provided hwaddr on all interfaces */
-	if (dnssd->interfaceCount == 0) {
-		dnssd->interfaces[0].ifIndex = 0;  /* kDNSServiceInterfaceIndexAny */
-		memcpy(dnssd->interfaces[0].hwaddr, hwaddr, hwaddrlen);
-		dnssd->interfaces[0].valid = 1;
-		dnssd->interfaceCount = 1;
+	ret = utils_hwaddr_airplay(deviceid, sizeof(deviceid), hwaddr, hwaddrlen);
+	if (ret < 0) {
+		return -1;
 	}
 
 	snprintf(features, sizeof(features), "0x%X,0x%X", GLOBAL_FEATURES_1, GLOBAL_FEATURES_2);
 
-	dnssd->airplayServiceCount = 0;
+	dnssd->TXTRecordCreate(&txtRecord, 0, NULL);
+	dnssd->TXTRecordSetValue(&txtRecord, "srcvers", strlen(GLOBAL_VERSION), GLOBAL_VERSION);
+	dnssd->TXTRecordSetValue(&txtRecord, "deviceid", strlen(deviceid), deviceid);
+	dnssd->TXTRecordSetValue(&txtRecord, "features", strlen(features), features);
+	dnssd->TXTRecordSetValue(&txtRecord, "model", strlen(GLOBAL_MODEL), GLOBAL_MODEL);
+	dnssd->TXTRecordSetValue(&txtRecord, "flags", strlen(RAOP_SF), RAOP_SF);
+	dnssd->TXTRecordSetValue(&txtRecord, "pw",
+		password ? strlen("true") : strlen("false"),
+		password ? "true" : "false");
+	dnssd->TXTRecordSetValue(&txtRecord, "vv", strlen(RAOP_VV), RAOP_VV);
 
-	/* Register service on each interface */
-	for (i = 0; i < dnssd->interfaceCount && i < MAX_INTERFACES; i++) {
-		if (!dnssd->interfaces[i].valid) {
-			continue;
-		}
+	dnssd->airplayService = NULL;
+	ret = dnssd->DNSServiceRegister(&dnssd->airplayService,
+		0, 0, /* kDNSServiceInterfaceIndexAny */
+		name, "_airplay._tcp",
+		NULL, NULL,
+		htons(port),
+		dnssd->TXTRecordGetLength(&txtRecord),
+		dnssd->TXTRecordGetBytesPtr(&txtRecord),
+		MyRegisterServiceReply, NULL);
+	dnssd->TXTRecordDeallocate(&txtRecord);
 
-		/* Use the interface's MAC address or fallback to provided hwaddr */
-		if_hwaddr = dnssd->interfaces[i].hwaddr;
-		if (if_hwaddr[0] == 0 && if_hwaddr[1] == 0 && if_hwaddr[2] == 0 &&
-			if_hwaddr[3] == 0 && if_hwaddr[4] == 0 && if_hwaddr[5] == 0) {
-			if_hwaddr = hwaddr;
-		}
-
-		/* Convert hardware address to string */
-		ret = utils_hwaddr_airplay(deviceid, sizeof(deviceid), if_hwaddr, hwaddrlen);
-		if (ret < 0) {
-			continue;
-		}
-
-		dnssd->TXTRecordCreate(&txtRecord, 0, NULL);
-		dnssd->TXTRecordSetValue(&txtRecord, "srcvers", strlen(GLOBAL_VERSION), GLOBAL_VERSION);
-		dnssd->TXTRecordSetValue(&txtRecord, "deviceid", strlen(deviceid), deviceid);
-		dnssd->TXTRecordSetValue(&txtRecord, "features", strlen(features), features);
-		dnssd->TXTRecordSetValue(&txtRecord, "model", strlen(GLOBAL_MODEL), GLOBAL_MODEL);
-		dnssd->TXTRecordSetValue(&txtRecord, "flags", strlen(RAOP_SF), RAOP_SF);
-		dnssd->TXTRecordSetValue(&txtRecord, "pw",
-			password ? strlen("true") : strlen("false"),
-			password ? "true" : "false");
-		dnssd->TXTRecordSetValue(&txtRecord, "vv", strlen(RAOP_VV), RAOP_VV);
-
-		/* Register the service on this interface */
-		ret = dnssd->DNSServiceRegister(&dnssd->airplayServices[dnssd->airplayServiceCount],
-		                          0, dnssd->interfaces[i].ifIndex,
-		                          name, "_airplay._tcp",
-		                          NULL, NULL,
-		                          htons(port),
-		                          dnssd->TXTRecordGetLength(&txtRecord),
-		                          dnssd->TXTRecordGetBytesPtr(&txtRecord),
-		                          MyRegisterServiceReply, NULL);
-
-		/* Deallocate TXT record */
-		dnssd->TXTRecordDeallocate(&txtRecord);
-
-		if (ret == 0) {
-			dnssd->airplayServiceCount++;
-			registered++;
-		}
+	if (ret != 0) {
+		dnssd->airplayService = NULL;
+		return -1;
 	}
 
-	return registered > 0 ? 0 : -1;
+	return 0;
 }
 
 void
 dnssd_unregister_raop(dnssd_t *dnssd)
 {
-	int i;
 	assert(dnssd);
 
-	/* Deallocate all RAOP service registrations */
-	for (i = 0; i < dnssd->raopServiceCount && i < MAX_INTERFACES; i++) {
-		if (dnssd->raopServices[i]) {
-			dnssd->DNSServiceRefDeallocate(dnssd->raopServices[i]);
-			dnssd->raopServices[i] = NULL;
-		}
+	if (dnssd->raopService) {
+		dnssd->DNSServiceRefDeallocate(dnssd->raopService);
+		dnssd->raopService = NULL;
 	}
-	dnssd->raopServiceCount = 0;
 }
 
 void
 dnssd_unregister_airplay(dnssd_t *dnssd)
 {
-	int i;
 	assert(dnssd);
 
-	/* Deallocate all AirPlay service registrations */
-	for (i = 0; i < dnssd->airplayServiceCount && i < MAX_INTERFACES; i++) {
-		if (dnssd->airplayServices[i]) {
-			dnssd->DNSServiceRefDeallocate(dnssd->airplayServices[i]);
-			dnssd->airplayServices[i] = NULL;
-		}
+	if (dnssd->airplayService) {
+		dnssd->DNSServiceRefDeallocate(dnssd->airplayService);
+		dnssd->airplayService = NULL;
 	}
-	dnssd->airplayServiceCount = 0;
 }

--- a/airplay2dll/src/FgAirplayServer.cpp
+++ b/airplay2dll/src/FgAirplayServer.cpp
@@ -1,15 +1,18 @@
 ﻿#include "pch.h"
 #include "FgAirplayServer.h"
 #include "Airplay2Head.h"
+#include <limits>
 #include <thread>
+#include <vector>
 #include "CAutoLock.h"
 
-#ifdef WIN32
-#include   "iphlpapi.h"  
-#pragma   comment(lib,   "iphlpapi.lib   ")  
+#ifdef _WIN32
+#include <ws2tcpip.h>
+#include <iphlpapi.h>
+#pragma comment(lib, "iphlpapi.lib")
 #endif
 
-BOOL GetMacAddress(char strMac[6]);
+static BOOL GetPrimaryMacAddress(char strMac[6]);
 
 FgAirplayServer::FgAirplayServer()
 	: m_pCallback(NULL)
@@ -71,7 +74,7 @@ int FgAirplayServer::start(const char serverName[AIRPLAY_NAME_LEN],
 	int ret = 0;
 	do {
 
-		GetMacAddress(hwaddr);
+		GetPrimaryMacAddress(hwaddr);
 
 		m_pAirplay = airplay_init(10, &m_stAirplayCB, pemstr, &ret);
 		if (m_pAirplay == NULL) {
@@ -431,41 +434,162 @@ void FgAirplayServer::log_callback(void* cls, int level, const char* msg)
 	}
 }
 
-BOOL GetMacAddress(char strMac[6])
+static bool IsUsableUnicastAddress(const IP_ADAPTER_UNICAST_ADDRESS* address)
 {
-	PIP_ADAPTER_INFO pAdapterInfo;
-	DWORD AdapterInfoSize;
-	DWORD Err;
-	AdapterInfoSize = 0;
-	Err = GetAdaptersInfo(NULL, &AdapterInfoSize);
-	if ((Err != 0) && (Err != ERROR_BUFFER_OVERFLOW)) {
-		printf("���������Ϣʧ��!");
-		return   FALSE;
+	if (address == NULL || address->Address.lpSockaddr == NULL) {
+		return false;
 	}
-	//   ����������Ϣ�ڴ�  
-	pAdapterInfo = (PIP_ADAPTER_INFO)GlobalAlloc(GPTR, AdapterInfoSize);
-	if (pAdapterInfo == NULL) {
-		printf("����������Ϣ�ڴ�ʧ��");
-		return   FALSE;
+	if (address->DadState != IpDadStatePreferred &&
+		address->DadState != IpDadStateDeprecated) {
+		return false;
 	}
-	if (GetAdaptersInfo(pAdapterInfo, &AdapterInfoSize) != 0) {
-		printf("���������Ϣʧ��!\n");
-		GlobalFree(pAdapterInfo);
-		return   FALSE;
-	}
-	for (int i = 0; i < 6; i++)
-	{
-		strMac[i] = pAdapterInfo->Address[i];
-	}
-// 	strMac[0] = pAdapterInfo->Address[0];
-// 	sprintf_s(strMac, 7, "%02X%02X%02X%02X%02X%02X",
-// 		pAdapterInfo->Address[0],
-// 		pAdapterInfo->Address[1],
-// 		pAdapterInfo->Address[2],
-// 		pAdapterInfo->Address[3],
-// 		pAdapterInfo->Address[4],
-// 		pAdapterInfo->Address[5]);
 
-	GlobalFree(pAdapterInfo);
-	return   TRUE;
+	if (address->Address.lpSockaddr->sa_family == AF_INET) {
+		const sockaddr_in* ipv4 =
+			reinterpret_cast<const sockaddr_in*>(address->Address.lpSockaddr);
+		return ipv4->sin_addr.s_addr != INADDR_ANY &&
+			ipv4->sin_addr.s_addr != INADDR_BROADCAST;
+	}
+
+	if (address->Address.lpSockaddr->sa_family == AF_INET6) {
+		const sockaddr_in6* ipv6 =
+			reinterpret_cast<const sockaddr_in6*>(address->Address.lpSockaddr);
+		return !IN6_IS_ADDR_UNSPECIFIED(&ipv6->sin6_addr) &&
+			!IN6_IS_ADDR_MULTICAST(&ipv6->sin6_addr);
+	}
+
+	return false;
+}
+
+static bool GetUsableAddressFamilies(const IP_ADAPTER_ADDRESSES* adapter,
+	bool* hasIpv4, bool* hasIpv6)
+{
+	*hasIpv4 = false;
+	*hasIpv6 = false;
+
+	for (const IP_ADAPTER_UNICAST_ADDRESS* address = adapter->FirstUnicastAddress;
+		address != NULL; address = address->Next) {
+		if (!IsUsableUnicastAddress(address)) {
+			continue;
+		}
+
+		if (address->Address.lpSockaddr->sa_family == AF_INET) {
+			*hasIpv4 = true;
+		}
+		else if (address->Address.lpSockaddr->sa_family == AF_INET6) {
+			*hasIpv6 = true;
+		}
+	}
+
+	return *hasIpv4 || *hasIpv6;
+}
+
+static bool HasUsableGateway(const IP_ADAPTER_ADDRESSES* adapter)
+{
+	for (const IP_ADAPTER_GATEWAY_ADDRESS_LH* gateway = adapter->FirstGatewayAddress;
+		gateway != NULL; gateway = gateway->Next) {
+		if (gateway->Address.lpSockaddr == NULL) {
+			continue;
+		}
+
+		if (gateway->Address.lpSockaddr->sa_family == AF_INET) {
+			const sockaddr_in* ipv4 =
+				reinterpret_cast<const sockaddr_in*>(gateway->Address.lpSockaddr);
+			if (ipv4->sin_addr.s_addr != INADDR_ANY) {
+				return true;
+			}
+		}
+		else if (gateway->Address.lpSockaddr->sa_family == AF_INET6) {
+			const sockaddr_in6* ipv6 =
+				reinterpret_cast<const sockaddr_in6*>(gateway->Address.lpSockaddr);
+			if (!IN6_IS_ADDR_UNSPECIFIED(&ipv6->sin6_addr)) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+static ULONG GetAdapterMetric(const IP_ADAPTER_ADDRESSES* adapter,
+	bool hasIpv4, bool hasIpv6)
+{
+	ULONG metric = (std::numeric_limits<ULONG>::max)();
+	if (hasIpv4) {
+		metric = adapter->Ipv4Metric;
+	}
+	if (hasIpv6 && adapter->Ipv6Metric < metric) {
+		metric = adapter->Ipv6Metric;
+	}
+	return metric;
+}
+
+static BOOL GetPrimaryMacAddress(char strMac[6])
+{
+	const ULONG flags = GAA_FLAG_INCLUDE_GATEWAYS |
+		GAA_FLAG_SKIP_ANYCAST |
+		GAA_FLAG_SKIP_MULTICAST |
+		GAA_FLAG_SKIP_DNS_SERVER;
+	ULONG bufferSize = 15 * 1024;
+	std::vector<unsigned char> buffer(bufferSize);
+	DWORD result = ERROR_BUFFER_OVERFLOW;
+
+	for (int attempt = 0; attempt < 3 && result == ERROR_BUFFER_OVERFLOW; ++attempt) {
+		buffer.resize(bufferSize);
+		result = GetAdaptersAddresses(AF_UNSPEC, flags, NULL,
+			reinterpret_cast<IP_ADAPTER_ADDRESSES*>(buffer.data()), &bufferSize);
+	}
+	if (result != NO_ERROR) {
+		return FALSE;
+	}
+
+	const IP_ADAPTER_ADDRESSES* bestAdapter = NULL;
+	bool bestHasGateway = false;
+	ULONG bestMetric = (std::numeric_limits<ULONG>::max)();
+
+	for (const IP_ADAPTER_ADDRESSES* adapter =
+		reinterpret_cast<const IP_ADAPTER_ADDRESSES*>(buffer.data());
+		adapter != NULL; adapter = adapter->Next) {
+		if (adapter->OperStatus != IfOperStatusUp ||
+			(adapter->Flags & IP_ADAPTER_NO_MULTICAST) != 0 ||
+			adapter->PhysicalAddressLength != 6 ||
+			adapter->IfType == IF_TYPE_SOFTWARE_LOOPBACK ||
+			adapter->IfType == IF_TYPE_TUNNEL) {
+			continue;
+		}
+
+		bool hasNonZeroMac = false;
+		for (ULONG i = 0; i < adapter->PhysicalAddressLength; ++i) {
+			if (adapter->PhysicalAddress[i] != 0) {
+				hasNonZeroMac = true;
+				break;
+			}
+		}
+		if (!hasNonZeroMac) {
+			continue;
+		}
+
+		bool hasIpv4;
+		bool hasIpv6;
+		if (!GetUsableAddressFamilies(adapter, &hasIpv4, &hasIpv6)) {
+			continue;
+		}
+
+		const bool hasGateway = HasUsableGateway(adapter);
+		const ULONG metric = GetAdapterMetric(adapter, hasIpv4, hasIpv6);
+		if (bestAdapter == NULL ||
+			(hasGateway && !bestHasGateway) ||
+			(hasGateway == bestHasGateway && metric < bestMetric)) {
+			bestAdapter = adapter;
+			bestHasGateway = hasGateway;
+			bestMetric = metric;
+		}
+	}
+
+	if (bestAdapter == NULL) {
+		return FALSE;
+	}
+
+	memcpy(strMac, bestAdapter->PhysicalAddress, 6);
+	return TRUE;
 }


### PR DESCRIPTION
## Summary

- Select the primary usable Windows network adapter for AirPlay identification.
- Prefer adapters with gateways and the lowest applicable IPv4/IPv6 metric.
- Register Bonjour services once on the selected adapter context instead of enumerating every interface.

## Testing

- Not run (no test results provided).